### PR TITLE
Fix default icon

### DIFF
--- a/app/api/index.js
+++ b/app/api/index.js
@@ -12,18 +12,20 @@ export async function fetchMyFeed(tokens: Tokens) {
     // loginUrl : 'https://test.salesforce.com'
   });
   try {
-    const result = await conn.chatter
-      .resource('/feeds/news/me/feed-elements')
-      .promise();
+    const result = await conn.request({
+      url: '/chatter/feeds/news/me/feed-elements', 
+      headers: { 'X-Connect-Theme' : 'Salesforce1' }
+    });
     return result.elements;
   } catch (err) {
     if (err.errorCode === 'INVALID_SESSION_ID') {
       const newTokens = await refreshToken(tokens.refreshToken);
       conn.accessToken = newTokens.access_token;
       console.log('New access token', newTokens);
-      const result = await conn.chatter
-        .resource('/feeds/news/me/feed-elements')
-        .promise();
+      const result = await conn.request({
+        url: '/chatter/feeds/news/me/feed-elements', 
+        headers: { 'X-Connect-Theme' : 'Salesforce1' }
+      });
       return result.elements;
     }
     console.log('Failed to fetch my feed', err.errorCode, err);

--- a/app/components/Feed.js
+++ b/app/components/Feed.js
@@ -2,7 +2,7 @@
 import React, { Component } from 'react';
 import { Spinner as ReactLDSSpinner } from 'react-lightning-design-system';
 import type { FeedItem as FeedItemPropsType } from '../types/FeedItem';
-import FeedItem from './FeedItem';
+import FeedItem from '../containers/FeedItem';
 
 type Props = {
   feedItems: Array<FeedItemPropsType>,

--- a/app/components/FeedItem.js
+++ b/app/components/FeedItem.js
@@ -8,6 +8,7 @@ import type { FeedItem as FeedItemPropsType } from '../types/FeedItem';
 type Props = {
   item: FeedItemPropsType,
   instanceUrl: string,
+  accessToken: string,
 };
 
 type HeaderProps = {
@@ -172,7 +173,7 @@ export default class FeedItem extends Component<Props> {
             id={this.props.item.id}
             name={this.props.item.actor.displayName}
             actorId={this.props.item.actor.id}
-            photoUrl={this.props.item.actor.photo.standardEmailPhotoUrl}
+            photoUrl={`${this.props.item.actor.photo.smallPhotoUrl}?oauth_token=${this.props.accessToken}`}
             relativeCreatedDate={this.props.item.relativeCreatedDate}
             instanceUrl={this.props.instanceUrl}
           />

--- a/app/containers/FeedItem.js
+++ b/app/containers/FeedItem.js
@@ -1,0 +1,9 @@
+// @flow
+import { connect } from 'react-redux';
+import FeedItem from '../components/FeedItem';
+
+const mapStateToProps = state => ({
+  accessToken: state.tokens.accessToken,
+});
+
+export default connect(mapStateToProps)(FeedItem);


### PR DESCRIPTION
## What does this PR do
* Fix #25 
* Use themed default icon  (e.g., Astro icon in Lightning Experience)

<img width="480" alt="screenshot" src="https://user-images.githubusercontent.com/1404346/76674527-bff23000-65f3-11ea-8e41-41e0ae6ea126.png">

## Approach
* Use bigger icon than the size of `slds-avatar_large` (3 rem)
  * The default size of `smallPhotoUrl` is 64x64 pixels
  * `smallPhotoUrl` requires an access token
    * https://developer.salesforce.com/blogs/developer-relations/2011/03/accessing-chatter-user-pics.html
* Add `X-Connect-Theme` request header to retrieve the themed icon.
  * https://developer.salesforce.com/docs/atlas.en-us.chatterapi.meta/chatterapi/connect_responses_pictures.htm
  * Using `Connection#request` because currently [chatter resource in jsforce doesn't support custom header](https://github.com/jsforce/jsforce/issues/883)

@zaki-yama 